### PR TITLE
소환사 리그 정보 없을 시 빈 객체를 내려보내도록 수정

### DIFF
--- a/src/main/java/gg/troll/report/api/league/service/LeagueService.java
+++ b/src/main/java/gg/troll/report/api/league/service/LeagueService.java
@@ -25,7 +25,7 @@ public class LeagueService {
         if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
             String body = new BasicResponseHandler().handleResponse(response);
             List<LeagueEntryDTO> leagueEntryDTOList = new ObjectMapper().readValue(body, new TypeReference<List<LeagueEntryDTO>>(){});
-            return leagueEntryDTOList.get(0);
+            return leagueEntryDTOList.size() > 0 ? leagueEntryDTOList.get(0) : new LeagueEntryDTO();
         } else {
             throw new Exception();
         }


### PR DESCRIPTION
* 리그 정보가 없을 경우 Default LeagueEntryDTO로 처리한다.